### PR TITLE
fix: improve NuGet push error handling in CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -215,9 +215,15 @@ jobs:
     
     - name: Push to NuGet
       if: steps.should_release.outputs.new_release == 'true'
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
+        if [ -z "$NUGET_API_KEY" ]; then
+          echo "Error: NUGET_API_KEY is not set. Please add it to your repository secrets."
+          exit 1
+        fi
         dotnet nuget push "./artifacts/*.nupkg" \
-          --api-key "${{ secrets.NUGET_API_KEY }}" \
+          --api-key "$NUGET_API_KEY" \
           --source "https://api.nuget.org/v3/index.json" \
           --skip-duplicate
     

--- a/Demo/Pages/Index/Index.razor
+++ b/Demo/Pages/Index/Index.razor
@@ -51,7 +51,7 @@
 
         <h1 class="hero-title">@Localizer["WelcomeToBlazorKawaii"]</h1>
         <p class="hero-subtitle">@Localizer["CuteCustomizableSVGComponents"]</p>
-        
+
         <MudStack Row="true" Justify="Justify.Center" Spacing="4" Class="mt-6">
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
@@ -81,9 +81,9 @@
         <div class="demo-kawaii-container">
             @{
                 var components = _demoComponents.ToList();
-                var spacing = 120; // Horizontal spacing between items
-                var waveAmplitude = 20; // Vertical wave amplitude
-                var waveSpeed = 0.02; // Speed of the wave
+                const int spacing = 120; // Horizontal spacing between items
+                const int waveAmplitude = 20; // Vertical wave amplitude
+                const double waveSpeed = 0.02; // Speed of the wave
             }
             @foreach (var (component, index) in components.Select((c, i) => (c, i)))
             {


### PR DESCRIPTION
This pull request introduces improvements to the CI/CD workflow and refactors constants in the `Index.razor` file to enhance maintainability and code clarity. The changes focus on ensuring secure handling of secrets in the CI/CD pipeline and improving code readability by using `const` for immutable values.

### CI/CD Workflow Enhancements:
* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R218-R226): Added validation to ensure `NUGET_API_KEY` is set before pushing to NuGet, improving error handling and security.

### Code Refactoring:
* [`Demo/Pages/Index/Index.razor`](diffhunk://#diff-d6f912a3807b65999756d2bbdd0550f56602766aaf65db33373c00f7fdd630cfL84-R86): Refactored variables `spacing`, `waveAmplitude`, and `waveSpeed` to `const` for better readability and to indicate immutability.- Add explicit check for NUGET_API_KEY environment variable
- Provide clearer error message when API key is missing
- Use environment variable instead of direct secret interpolation
- This helps identify if the issue is a missing secret vs invalid key

To fix the 403 error, you need to:
1. Create a new API key at https://www.nuget.org/account/apikeys
2. Add it to GitHub repository secrets as NUGET_API_KEY
3. Ensure the key has 'Push' permissions for BlazorKawaii package

🤖 Generated with Claude Code