### PR TITLE
fix: resolve symbol package push error by using embedded symbols

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -236,7 +236,6 @@ jobs:
         body: ${{ steps.changelog.outputs.clean_changelog }}
         files: |
           ./artifacts/*.nupkg
-          ./artifacts/*.snupkg
         draft: false
         prerelease: false
       env:

--- a/BlazorKawaii/BlazorKawaii.csproj
+++ b/BlazorKawaii/BlazorKawaii.csproj
@@ -26,10 +26,11 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     
     <!-- Symbol/Debug Information -->
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Using embedded symbols instead of separate symbol package -->
+    <IncludeSymbols>false</IncludeSymbols>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BlazorKawaii is a Blazor WebAssembly component library that provides cute, customizable SVG components. It's a port of the React Kawaii library to the .NET ecosystem, featuring 16 kawaii components with 7 different mood expressions.
+
+## Build Commands
+
+### Development
+```bash
+# Restore dependencies
+dotnet restore
+
+# Build the entire solution
+dotnet build
+
+# Build in Release mode
+dotnet build --configuration Release
+
+# Run the demo application
+dotnet run --project Demo/Demo.csproj
+
+# Watch mode for development
+dotnet watch run --project Demo/Demo.csproj
+```
+
+### Testing & Validation
+```bash
+# Run tests (when available)
+dotnet test
+
+# Validate NuGet package
+dotnet tool install -g Meziantou.Framework.NuGetPackageValidation.Tool
+meziantou.validate-nuget-package ./artifacts/*.nupkg
+```
+
+### Publishing
+```bash
+# Pack the library for NuGet
+dotnet pack BlazorKawaii/BlazorKawaii.csproj --configuration Release --output ./artifacts
+
+# Publish demo for GitHub Pages
+dotnet publish Demo/Demo.csproj --configuration Release --output ./dist -p:GHPages=true
+```
+
+## Architecture
+
+### Solution Structure
+- **BlazorKawaii/** - The main Razor Class Library (RCL) containing all kawaii components
+- **Demo/** - Blazor WebAssembly demo application showcasing the components
+
+### Component Architecture
+
+All components inherit from `KawaiiComponentBase` which provides:
+- Common parameters: `Size`, `Mood`, `Color`, `Class`, `Style`, `SvgClass`, `SvgStyle`
+- Unique ID generation for SVG masks to prevent conflicts
+- Abstract methods for face positioning and scaling
+
+Each component consists of:
+1. **Component.razor** - SVG markup using the Wrapper component
+2. **Component.razor.cs** - Partial class inheriting from KawaiiComponentBase
+3. **ComponentPaths.cs** - Static class containing SVG path data
+
+### Key Design Patterns
+
+1. **SVG Mask Isolation**: Each component instance gets a unique ID to prevent SVG mask conflicts when multiple components are on the same page.
+
+2. **Culture-Invariant Formatting**: All numeric values in SVG attributes use `CultureInfo.InvariantCulture` to prevent decimal separator issues in different locales.
+
+3. **Face Positioning**: Each component implements `GetFaceScale()` and `GetFacePosition()` to properly position the Face component based on React Kawaii's Figma measurements.
+
+4. **Wrapper Pattern**: All components use the `<Wrapper>` component for consistent sizing and positioning.
+
+### Localization
+
+The demo app supports multiple languages (EN, FR, ES, NL) with:
+- Resource files in `Demo/Resources/`
+- `LanguageService` for URL-based language persistence
+- Culture configuration in `WebAssemblyHostExtensions`
+
+### CI/CD Pipeline
+
+The GitHub Actions workflow (`ci-cd.yml`) handles:
+- Multi-OS builds (Ubuntu, Windows, macOS)
+- Automatic versioning using conventional commits
+- NuGet package validation and publishing
+- GitHub Pages deployment
+- Deterministic builds for reproducible packages
+
+### Important Configuration
+
+1. **Central Package Management**: Uses `Directory.Packages.props` for consistent package versions
+2. **Deterministic Builds**: Configured in `Directory.Build.props` for reproducible builds
+3. **Symbol Generation**: Includes .snupkg files for debugging support
+4. **XML Documentation**: Generated for IntelliSense support
+
+### Common Issues & Solutions
+
+1. **DOM Manipulation Errors**: The demo uses Prism.js for syntax highlighting. To prevent conflicts with Blazor's DOM updates, code highlighting is wrapped in try-catch blocks and only runs on first render.
+
+2. **SVG Rendering Issues**: Always use `SvgFormatHelper.FormatSvgNumber()` for numeric SVG attributes to ensure culture-invariant formatting.
+
+3. **Generic Type Inference**: MudBlazor components like `MudList` require explicit type parameters (e.g., `T="string"`).
+
+### NuGet Publishing
+
+To publish to NuGet.org:
+1. Create an API key at https://www.nuget.org/account/apikeys
+2. Add it as `NUGET_API_KEY` in GitHub repository secrets
+3. The CI/CD pipeline will automatically publish on new version tags

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,5 @@
     <!-- SourceLink settings -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request introduces several changes to improve the build configuration, documentation, and CI/CD pipeline for the `BlazorKawaii` project. The most notable updates include transitioning to embedded symbols for debugging, adding comprehensive project documentation, and refining CI/CD settings to align with the new symbol format.

### Build Configuration Updates:
* [`BlazorKawaii/BlazorKawaii.csproj`](diffhunk://#diff-37299688bd259139246066eb8043006b8807adacd39c728310f423dd0de72974L29-R33): Switched to embedded symbols for debugging by disabling separate symbol packages (`snupkg`) and enabling `EmbedAllSources`. This ensures that all debug information is included directly in the assembly.
* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL32): Removed `.pdb` as an allowed output extension in the package build output folder, aligning with the embedded symbols approach.

### CI/CD Pipeline Refinements:
* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L239): Removed support for `.snupkg` files in the artifact list, reflecting the transition to embedded symbols.

### Documentation Enhancements:
* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R112): Added a detailed project overview, build commands, architecture explanation, CI/CD pipeline details, and common troubleshooting tips for contributors and AI tools. This documentation provides a comprehensive guide for working with the `BlazorKawaii` repository.- Disable separate symbol package generation (IncludeSymbols=false)
- Keep embedded debug symbols in the main DLL (DebugType=embedded)
- Add EmbedAllSources=true for complete debugging experience
- Remove .snupkg files from GitHub release artifacts
- Remove .pdb extension from build output folder configuration

This fixes the 400 error when pushing symbol packages to NuGet. Embedded symbols provide a simpler deployment model where debug information is included directly in the DLL, eliminating the need for separate .snupkg files.

🤖 Generated with Claude Code