### PR TITLE
fix(deps): downgrade ASP.NET packages to 9.0.x for net9.0 compatibility

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   
   <ItemGroup>
     <!-- Blazor -->
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.3" />
     
     <!-- MudBlazor -->
     <PackageVersion Include="MudBlazor" Version="9.1.0" />
@@ -17,7 +17,7 @@
     <PackageVersion Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />
     
     <!-- Localization -->
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.3" />
     
     <!-- SourceLink for deterministic builds -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />


### PR DESCRIPTION
## Summary
- Downgrade `Microsoft.AspNetCore.Components.Web`, `Microsoft.AspNetCore.Components.WebAssembly`, `Microsoft.AspNetCore.Components.WebAssembly.DevServer`, and `Microsoft.AspNetCore.WebUtilities` from 10.0.3 to 9.0.3
- Downgrade `Microsoft.Extensions.Localization` from 10.0.3 to 9.0.3
- These 10.0.x packages target net10.0 and are incompatible with the project's net9.0 TFM, causing CI build failures

## Test plan
- [ ] Verify `dotnet restore` succeeds (confirmed locally)
- [ ] Verify CI build passes on this branch