### PR TITLE
fix(ci): use .NET 9.0.x in ci.yml to match project target framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '9.0.x'
       - run: dotnet restore
       - run: dotnet build --no-restore -c Release
       - run: dotnet test --no-build -c Release --no-restore


### PR DESCRIPTION
## Summary
- Fixes CI failure in PR #91 (and the `ci.yml` workflow in general) by changing `dotnet-version` from `10.0.x` to `9.0.x`
- The project targets `net9.0`, so .NET SDK 10.0.x resolves incompatible NuGet packages (e.g. `Microsoft.AspNetCore.Components.Web 10.0.3` which only supports `net10.0`), causing `NU1202` restore errors
- The `ci-cd.yml` workflow already correctly uses `9.0.x`; this aligns `ci.yml` to match

## Test plan
- [ ] Verify CI passes on this PR (dotnet restore, build, and test should succeed)
- [ ] Confirm PR #91 can be rebased on top of this fix and also pass CI