### PR TITLE
chore: upgrade target framework to .NET 10

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet-version: ['9.0.x']
+        dotnet-version: ['10.0.x']
     
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'

--- a/BlazorKawaii/BlazorKawaii.csproj
+++ b/BlazorKawaii/BlazorKawaii.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>


### PR DESCRIPTION
## Summary
- Update `BlazorKawaii.csproj` and `Demo.csproj` to target `net10.0` instead of `net9.0`
- Update `ci-cd.yml` dotnet-version from `9.0.x` to `10.0.x` (both env variable and matrix)
- Update `ci.yml` to use `actions/checkout@v6` for consistency

## Context
The `Directory.Packages.props` already references .NET 10 packages (e.g., `Microsoft.AspNetCore.Components.Web` 10.0.3), but the project files were still targeting `net9.0` and CI was using `dotnet-version: '9.0.x'`. This mismatch caused CI build failures.

PR #94 incorrectly attempted to fix this by downgrading the CI SDK to 9.0.x — that PR has been closed. The correct fix is to update the project to target .NET 10, which is what this PR does.

## Test plan
- [x] `dotnet build --configuration Release` succeeds locally with 0 warnings, 0 errors
- [ ] CI pipeline passes with .NET 10 SDK