### PR TITLE
ci: publish to NuGet via Trusted Publishing, not a long-lived key

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -213,17 +213,31 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: ${{ steps.get_version.outputs.new_version }}
     
-    - name: Push to NuGet
+    # Trusted Publishing: no long-lived API key. The login step exchanges this workflow's OIDC
+    # token (permissions.id-token: write, declared at workflow level and inherited by this job) for
+    # a NuGet key valid ~1 hour, so it must stay adjacent to the push below.
+    - name: Check NuGet publishing is configured
       if: steps.should_release.outputs.new_release == 'true'
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_USER: ${{ secrets.NUGET_USER }}
       run: |
-        if [ -z "$NUGET_API_KEY" ]; then
-          echo "Error: NUGET_API_KEY is not set. Please add it to your repository secrets."
+        if [ -z "$NUGET_USER" ]; then
+          echo "Error: NUGET_USER is not set. Add it to your repository secrets (it is your nuget.org profile name, not an API key), and register a Trusted Publishing policy on nuget.org for the BlazorKawaii package naming this repository and ci-cd.yml."
           exit 1
         fi
+
+    - name: NuGet login (OIDC -> short-lived key)
+      id: nuget-login
+      if: steps.should_release.outputs.new_release == 'true'
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
+    - name: Push to NuGet
+      if: steps.should_release.outputs.new_release == 'true'
+      run: |
         dotnet nuget push "./artifacts/*.nupkg" \
-          --api-key "$NUGET_API_KEY" \
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
           --source "https://api.nuget.org/v3/index.json" \
           --skip-duplicate
     

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,13 @@ The GitHub Actions workflow (`ci-cd.yml`) handles:
 
 ### NuGet Publishing
 
-To publish to NuGet.org:
-1. Create an API key at https://www.nuget.org/account/apikeys
-2. Add it as `NUGET_API_KEY` in GitHub repository secrets
+Publishing uses [Trusted Publishing](https://learn.microsoft.com/nuget/nuget-org/trusted-publishing) —
+no long-lived API key is stored anywhere. The workflow exchanges GitHub's OIDC token for a NuGet key
+valid about an hour, used immediately.
+
+To set it up:
+1. On nuget.org, register a Trusted Publishing policy for the `BlazorKawaii` package, naming this
+   repository and the workflow file `ci-cd.yml`
+2. Add your nuget.org **profile name** as `NUGET_USER` in GitHub repository secrets — it is not a
+   credential; the OIDC exchange is what authorizes the push
 3. The CI/CD pipeline will automatically publish on new version tags


### PR DESCRIPTION
The `release` job pushed with a long-lived `NUGET_API_KEY` secret. It now uses **Trusted Publishing**: GitHub's OIDC token is exchanged for a NuGet key valid ~1 hour, used immediately. The only remaining secret is `NUGET_USER` — your nuget.org profile name, not a credential.

### What did not need changing

`permissions.id-token: write` was already declared at workflow level, and the `release` job declares no `permissions` block of its own, so it inherits it. Worth stating because the sibling `analyze` job *does* declare its own — had the push lived there, the token would have been silently absent.

### What I kept rather than replaced

The step had a guard that failed with "NUGET_API_KEY is not set. Please add it to your repository secrets." I kept that intent, retargeted at `NUGET_USER` and extended to name the nuget.org policy that must also exist. An actionable message beats the login action's raw failure.

### Required before the next release

1. Register a Trusted Publishing policy on nuget.org for the `BlazorKawaii` package, naming `phmatray/BlazorKawaii` and `ci-cd.yml`.
2. Set the `NUGET_USER` secret.
3. Cut one release, confirm the package appears, **then** delete `NUGET_API_KEY`.

`CLAUDE.md`'s NuGet Publishing section rewritten in the same change.